### PR TITLE
Internationalisation Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>java.net.countercraft.movecraft.combat</groupId>
     <artifactId>Movecraft-Combat</artifactId>
-    <version>0.6.32</version>
+    <version>0.7.0</version>
     <packaging>jar</packaging>
 
     <name>Movecraft-Combat</name>

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
@@ -3,6 +3,7 @@ package net.countercraft.movecraft.combat.movecraftcombat;
 import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.logging.Level;
 import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import org.bukkit.Material;
@@ -88,7 +89,6 @@ public final class MovecraftCombat extends JavaPlugin {
         Config.EnableCombatReleaseKick = getConfig().getBoolean("EnableCombatReleaseKick", true);
         Config.CombatReleaseBanLength = getConfig().getLong("CombatReleaseBanLength", 60);
         Config.CombatReleaseScuttle = getConfig().getBoolean("CombatReleaseScuttle", true);
-
 
 
         Plugin wg = getServer().getPluginManager().getPlugin("WorldGuard");

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
@@ -1,9 +1,10 @@
 package net.countercraft.movecraft.combat.movecraftcombat;
 
+import java.io.File;
 import java.util.Map;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.logging.Level;
+import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import org.bukkit.Material;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -34,6 +35,15 @@ public final class MovecraftCombat extends JavaPlugin {
         instance = this;
 
         saveDefaultConfig();
+
+        //TODO other languages
+        String[] languages = {"en"};
+        for (String s : languages) {
+            if (!new File(getDataFolder()  + "/localisation/mcclang_"+ s +".properties").exists()) {
+                this.saveResource("localisation/mcclang_"+ s +".properties", false);
+            }
+        }
+
         Config.Debug = getConfig().getBoolean("Debug", false);
         Config.AADirectorDistance = getConfig().getInt("AADirectorDistance", 50);
         Config.AADirectorRange = getConfig().getInt("AADirectorRange", 120);
@@ -43,6 +53,10 @@ public final class MovecraftCombat extends JavaPlugin {
         Config.EnableContactExplosives = getConfig().getBoolean("EnableContactExplosives", true);
         Config.CannonDirectorDistance = getConfig().getInt("CannonDirectorsDistance", 100);
         Config.CannonDirectorRange = getConfig().getInt("CannonDirectorRange", 120);
+        Config.Locale = getConfig().getString("Locale", "en");
+
+        I18nSupport.init();
+
         for(String s : getConfig().getStringList("CannonDirectorsAllowed")) {
             Config.CannonDirectorsAllowed.add(CraftManager.getInstance().getCraftTypeFromString(s));
         }
@@ -74,6 +88,7 @@ public final class MovecraftCombat extends JavaPlugin {
         Config.EnableCombatReleaseKick = getConfig().getBoolean("EnableCombatReleaseKick", true);
         Config.CombatReleaseBanLength = getConfig().getLong("CombatReleaseBanLength", 60);
         Config.CombatReleaseScuttle = getConfig().getBoolean("CombatReleaseScuttle", true);
+
 
 
         Plugin wg = getServer().getPluginManager().getPlugin("WorldGuard");

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
@@ -2,6 +2,7 @@ package net.countercraft.movecraft.combat.movecraftcombat.config;
 
 import java.util.HashMap;
 import java.util.HashSet;
+
 import org.bukkit.Material;
 import net.countercraft.movecraft.craft.CraftType;
 
@@ -46,4 +47,7 @@ public class Config {
     public static boolean EnableCombatReleaseKick = true;
     public static long CombatReleaseBanLength = 60;
     public static boolean CombatReleaseScuttle = true;
+
+    //Localisation
+    public static String Locale = "en";
 }

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
@@ -2,7 +2,6 @@ package net.countercraft.movecraft.combat.movecraftcombat.config;
 
 import java.util.HashMap;
 import java.util.HashSet;
-
 import org.bukkit.Material;
 import net.countercraft.movecraft.craft.CraftType;
 

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/localisation/I18nSupport.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/localisation/I18nSupport.java
@@ -1,0 +1,48 @@
+package net.countercraft.movecraft.combat.movecraftcombat.localisation;
+
+import net.countercraft.movecraft.combat.movecraftcombat.MovecraftCombat;
+import net.countercraft.movecraft.combat.movecraftcombat.config.Config;
+import java.io.*;
+import java.util.Properties;
+import java.util.logging.Level;
+
+public class I18nSupport {
+    private static Properties langFile;
+
+    public static void init() {
+        langFile = new Properties();
+
+        File langDirectory = new File(MovecraftCombat.getInstance().getDataFolder().getAbsolutePath() + "/localisation");
+        if (!langDirectory.exists()) {
+            langDirectory.mkdirs();
+        }
+
+        InputStream stream = null;
+
+        try {
+            stream = new FileInputStream(langDirectory.getAbsolutePath()+"/mcclang_" + Config.Locale + ".properties");
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+
+        if (stream == null) {
+            MovecraftCombat.getInstance().getLogger().log(Level.SEVERE, "Critical Error in localisation system!");
+            MovecraftCombat.getInstance().getServer().shutdown();
+        }
+
+        try {
+            langFile.load(stream);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static String getInternationalisedString(String key) {
+        String ret = langFile.getProperty(key);
+        if (ret != null) {
+            return ret;
+        } else {
+            return key;
+        }
+    }
+}

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/AADirectorSign.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/AADirectorSign.java
@@ -1,6 +1,7 @@
 package net.countercraft.movecraft.combat.movecraftcombat.sign;
 
 import net.countercraft.movecraft.combat.movecraftcombat.MovecraftCombat;
+import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -45,24 +46,24 @@ public class AADirectorSign implements Listener {
             }
         }
         if (foundCraft == null) {
-            player.sendMessage(ERROR_PREFIX + "Sign must be part of a piloted craft!");
+            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
             return;
         }
 
         if (!Config.AADirectorsAllowed.contains(foundCraft.getType())) {
-            player.sendMessage(ERROR_PREFIX + "AA Director signs not allowed on this craft!");
+            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("AADirector - Not Allowed On Craft"));
             return;
         }
 
         AADirectorManager aa = MovecraftCombat.getInstance().getAADirectors();
         if(event.getAction() == Action.LEFT_CLICK_BLOCK && aa.isDirector(player)){
             aa.removeDirector(event.getPlayer());
-            player.sendMessage("You are no longer directing the AA of this craft.");
+            player.sendMessage(I18nSupport.getInternationalisedString("AADirector - No Longer Directing"));
             return;
         }
 
         aa.addDirector(foundCraft, event.getPlayer());
-        player.sendMessage("You are now directing the AA of this craft");
+        player.sendMessage(I18nSupport.getInternationalisedString("AADirector - Directing"));
         if (MovecraftCombat.getInstance().getCannonDirectors().isDirector(player)) {
             MovecraftCombat.getInstance().getCannonDirectors().removeDirector(player);
         }

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/AADirectorSign.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/AADirectorSign.java
@@ -46,12 +46,12 @@ public class AADirectorSign implements Listener {
             }
         }
         if (foundCraft == null) {
-            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
+            player.sendMessage(ERROR_PREFIX + " " + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
             return;
         }
 
         if (!Config.AADirectorsAllowed.contains(foundCraft.getType())) {
-            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("AADirector - Not Allowed On Craft"));
+            player.sendMessage(ERROR_PREFIX + " " + I18nSupport.getInternationalisedString("AADirector - Not Allowed On Craft"));
             return;
         }
 

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/CannonDirectorSign.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/CannonDirectorSign.java
@@ -46,12 +46,12 @@ public class CannonDirectorSign implements Listener {
             }
         }
         if (foundCraft == null) {
-            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
+            player.sendMessage(ERROR_PREFIX + " " + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
             return;
         }
 
         if (!Config.CannonDirectorsAllowed.contains(foundCraft.getType())) {
-            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("CannonDirector - Not Allowed On Craft"));
+            player.sendMessage(ERROR_PREFIX + " " + I18nSupport.getInternationalisedString("CannonDirector - Not Allowed On Craft"));
             return;
         }
 

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/CannonDirectorSign.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/sign/CannonDirectorSign.java
@@ -1,6 +1,7 @@
 package net.countercraft.movecraft.combat.movecraftcombat.sign;
 
 import net.countercraft.movecraft.combat.movecraftcombat.MovecraftCombat;
+import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -45,24 +46,24 @@ public class CannonDirectorSign implements Listener {
             }
         }
         if (foundCraft == null) {
-            player.sendMessage(ERROR_PREFIX + "Sign must be part of a piloted craft!");
+            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("Sign - Must Be Part Of Craft"));
             return;
         }
 
         if (!Config.CannonDirectorsAllowed.contains(foundCraft.getType())) {
-            player.sendMessage(ERROR_PREFIX + "Cannon Director signs not allowed on this craft!");
+            player.sendMessage(ERROR_PREFIX + I18nSupport.getInternationalisedString("CannonDirector - Not Allowed On Craft"));
             return;
         }
 
         CannonDirectorManager cannons = MovecraftCombat.getInstance().getCannonDirectors();
         if(event.getAction() == Action.LEFT_CLICK_BLOCK && cannons.isDirector(player)){
             cannons.removeDirector(event.getPlayer());
-            player.sendMessage("Cannon Director signs not allowed on this craft!");
+            player.sendMessage(I18nSupport.getInternationalisedString("CannonDirector - No Longer Directing"));
             return;
         }
 
         cannons.addDirector(foundCraft, event.getPlayer());
-        player.sendMessage("You are now directing the cannons of this craft");
+        player.sendMessage(I18nSupport.getInternationalisedString("CannonDirector - Directing"));
         if (MovecraftCombat.getInstance().getAADirectors().isDirector(player)) {
             MovecraftCombat.getInstance().getAADirectors().removeDirector(player);
         }

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/status/StatusManager.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/status/StatusManager.java
@@ -10,6 +10,7 @@ import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 import net.countercraft.movecraft.MovecraftLocation;
 import net.countercraft.movecraft.combat.movecraftcombat.MovecraftCombat;
+import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import net.countercraft.movecraft.utils.HitBox;
 import org.bukkit.BanList;
 import org.bukkit.Bukkit;
@@ -97,7 +98,7 @@ public class StatusManager extends BukkitRunnable {
         if(isInAirspace(craft))
             return;
 
-        MovecraftCombat.getInstance().getLogger().info("Combat release! " + player.getName());
+        MovecraftCombat.getInstance().getLogger().info(I18nSupport.getInternationalisedString("Combat Release") + " " + player.getName());
         CombatReleaseEvent event = new CombatReleaseEvent(craft, player);
         Bukkit.getServer().getPluginManager().callEvent(event);
         if(event.isCancelled())
@@ -109,10 +110,10 @@ public class StatusManager extends BukkitRunnable {
         }
         if(Config.CombatReleaseBanLength > 0) {
             Date expiry = new Date(System.currentTimeMillis() + Config.CombatReleaseBanLength * 1000);
-            Bukkit.getServer().getBanList(BanList.Type.NAME).addBan(player.getName(), "Combat release!", expiry, "Movecraft-Combat AutoBan");
+            Bukkit.getServer().getBanList(BanList.Type.NAME).addBan(player.getName(), I18nSupport.getInternationalisedString("Combat Release"), expiry, "Movecraft-Combat AutoBan");
         }
         if(Config.CombatReleaseBanLength > 0 || Config.EnableCombatReleaseKick)
-            player.kickPlayer("Combat release!");
+            player.kickPlayer(I18nSupport.getInternationalisedString("Combat Release"));
     }
 
     public void craftSunk(@NotNull Craft craft) {
@@ -132,14 +133,14 @@ public class StatusManager extends BukkitRunnable {
         if(isInCombat(player))
             return;
         Bukkit.getServer().getPluginManager().callEvent(new CombatStartEvent(player));
-        player.sendMessage(ChatColor.RED + "You have now entered combat.");
-        MovecraftCombat.getInstance().getLogger().info(player.getName() + " has left combat.");
+        player.sendMessage(ChatColor.RED + I18nSupport.getInternationalisedString("Status - Enter Combat"));
+        MovecraftCombat.getInstance().getLogger().info(player.getName() + I18nSupport.getInternationalisedString("Log - Enter Combat"));
     }
 
     private void stopCombat(@NotNull Player player) {
         Bukkit.getServer().getPluginManager().callEvent(new CombatStopEvent(player));
-        player.sendMessage(ChatColor.RED + "You have now left combat.");
-        MovecraftCombat.getInstance().getLogger().info(player.getName() + " has left combat.");
+        player.sendMessage(ChatColor.RED + I18nSupport.getInternationalisedString("Status - Leave Combat"));
+        MovecraftCombat.getInstance().getLogger().info(player.getName() + I18nSupport.getInternationalisedString("Log - Leave Combat"));
     }
 
     // TODO: Replace this functionality with a listener in MCWG

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/status/StatusManager.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/status/StatusManager.java
@@ -134,13 +134,13 @@ public class StatusManager extends BukkitRunnable {
             return;
         Bukkit.getServer().getPluginManager().callEvent(new CombatStartEvent(player));
         player.sendMessage(ChatColor.RED + I18nSupport.getInternationalisedString("Status - Enter Combat"));
-        MovecraftCombat.getInstance().getLogger().info(player.getName() + I18nSupport.getInternationalisedString("Log - Enter Combat"));
+        MovecraftCombat.getInstance().getLogger().info(player.getName() + " " + I18nSupport.getInternationalisedString("Log - Enter Combat"));
     }
 
     private void stopCombat(@NotNull Player player) {
         Bukkit.getServer().getPluginManager().callEvent(new CombatStopEvent(player));
         player.sendMessage(ChatColor.RED + I18nSupport.getInternationalisedString("Status - Leave Combat"));
-        MovecraftCombat.getInstance().getLogger().info(player.getName() + I18nSupport.getInternationalisedString("Log - Leave Combat"));
+        MovecraftCombat.getInstance().getLogger().info(player.getName() + " " + I18nSupport.getInternationalisedString("Log - Leave Combat"));
     }
 
     // TODO: Replace this functionality with a listener in MCWG

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/tracking/DamageManager.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/tracking/DamageManager.java
@@ -2,6 +2,7 @@ package net.countercraft.movecraft.combat.movecraftcombat.tracking;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import net.countercraft.movecraft.combat.movecraftcombat.localisation.I18nSupport;
 import org.jetbrains.annotations.NotNull;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -86,12 +87,12 @@ public class DamageManager extends BukkitRunnable {
 
         StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append(sunk.getDisplayName());
-        stringBuilder.append(" was sunk by ");
+        stringBuilder.append(" " + I18nSupport.getInternationalisedString("Killfeed - Sunk By") + " ");
         stringBuilder.append(latestDamage.getCause().getDisplayName());
         if(players.size() < 1)
             return stringBuilder.toString();
 
-        stringBuilder.append(" with assists from: ");
+        stringBuilder.append(" " + I18nSupport.getInternationalisedString("Killfeed - With Assists") + " ");
         for(Player p : players) {
             stringBuilder.append(p.getDisplayName());
             stringBuilder.append(", ");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -61,3 +61,6 @@ EnableCombatReleaseTracking: false # Enable tracking of combat releasing
 EnableCombatReleaseKick: true # Enable combat release kick, overriden to true if CombatReleaseBanLength isn't 0
 CombatReleaseBanLength: 60 # Length of combat release ban in seconds, set to 0 to disable
 CombatReleaseScuttle: true # Enable scuttling of crafts when combat released
+
+# Localisation
+Locale: "en"

--- a/src/main/resources/localisation/mcclang_en.properties
+++ b/src/main/resources/localisation/mcclang_en.properties
@@ -1,0 +1,17 @@
+AADirector\ -\ Directing=You are now directing the AA of this craft
+AADirector\ -\ No\ Longer\ Directing=You are no longer directing the AA of this craft
+AADirector\ -\ Not\ Allowed\ On\ Craft=AA Director signs are not allowed on this type of craft
+Combat\ Release=Combat Release\!
+CannonDirector\ -\ Directing=You are now directing the cannons of this craft
+CannonDirector\ -\ No\ Longer\ Directing=You are no longer directing the cannons of this craft
+CannonDirector\ -\ Not\ Allowed\ On\ Craft=Cannon Director signs are not allowed on this type of craft
+Killfeed\ -\ Sunk\ By=was sunk by
+Killfeed\ -\ With\ Assists=with assists from
+Log\ -\ Enter\ Combat= has entered combat.
+Log\ -\ Leave\ Combat= has left combat.
+Sign\ -\ Must\ Be\ Part\ Of\ Craft=Sign must be part of a piloted craft\!
+Startup\ -\ Failed\ Load\ Transparent=Failed to load transparent 
+Startup\ -\ WG\ Found=Found a compatible version of WorldGuard. Enabling WorldGuard integration.
+Startup\ -\ WG\ Not\ Found=Movecraft Combat did not find a compatible version of WorldGuard. Disabling WorldGuard integration.
+Status\ -\ Enter\ Combat=You have now entered combat.
+Status\ -\ Leave\ Combat=You have now left combat.


### PR DESCRIPTION
Adds internationalisation support to all messages. Tested on 1.12.2, but I see no reason it wouldn't work on any other version. Currently the only language is English.

This will close #10 