### PR TITLE
Fix fire obstruction when Fireball Penetration is enabled

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/listener/IgniteListener.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/listener/IgniteListener.java
@@ -1,22 +1,12 @@
 package net.countercraft.movecraft.combat.movecraftcombat.listener;
 
 
-import com.sk89q.worldedit.bukkit.BukkitWorld;
-import com.sk89q.worldedit.math.BlockVector3;
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.Flags;
-import com.sk89q.worldguard.protection.flags.StateFlag;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import net.countercraft.movecraft.Movecraft;
+import net.countercraft.movecraft.combat.movecraftcombat.MovecraftCombat;
 import net.countercraft.movecraft.combat.movecraftcombat.config.Config;
-import net.countercraft.movecraft.config.Settings;
 import net.countercraft.movecraft.craft.Craft;
 import net.countercraft.movecraft.craft.CraftManager;
 import net.countercraft.movecraft.utils.MathUtils;
 import net.countercraft.movecraft.combat.movecraftcombat.utils.WorldGuard6Utils;
-import net.countercraft.movecraft.combat.movecraftcombat.utils.LegacyUtils;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -39,7 +29,7 @@ public class IgniteListener implements Listener {
             doFireballPenetration(event);
         }
 
-        // add surface fires to a craft's hitbox
+        // add surface fires to a craft's hitbox to prevent obstruction by fire
         if (Config.AddFiresToHitbox) {
             doAddFiresToHitbox(event);
         }
@@ -76,9 +66,10 @@ public class IgniteListener implements Listener {
 
     private void doAddFiresToHitbox(BlockIgniteEvent e) {
         final Craft craft = adjacentCraft(e.getBlock().getLocation());
-        if (craft != null) {
-            craft.getHitBox().add(MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation()));
-        }
+        if (craft == null || craft.getHitBox().isEmpty())
+            return;
+
+        craft.getHitBox().add(MathUtils.bukkit2MovecraftLoc(e.getBlock().getLocation()));
     }
 
     private void doFireballPenetration(BlockIgniteEvent e) {
@@ -102,21 +93,9 @@ public class IgniteListener implements Listener {
     }
 
     private boolean isFireSpreadAllowed(Location l) {
-        if(Movecraft.getInstance().getWorldGuardPlugin() != null && (Settings.WorldGuardBlockMoveOnBuildPerm ||Settings.WorldGuardBlockSinkOnPVPPerm)) {
-            if (LegacyUtils.getInstance().isLegacy()) {
-                if (!WorldGuard6Utils.locationAllowsFireSpread(l)) {
-                    return false;
-                }
-            } else {
-                RegionManager manager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(new BukkitWorld(l.getWorld()));
-                ApplicableRegionSet set = manager.getApplicableRegions(BlockVector3.at(l.getX(), l.getY(), l.getZ()));
-                for (ProtectedRegion region : set) {
-                    if (region.getFlag(Flags.FIRE_SPREAD) == StateFlag.State.DENY) {
-                        return false;
-                    }
-                }
-            }
+        if(MovecraftCombat.getInstance().getWGPlugin() == null) {
+            return true;
         }
-        return true;
+        return WorldGuard6Utils.isFireSpreadAllowed(l);
     }
 }


### PR DESCRIPTION
Previously, Fireball Penetration would cause the onBlockIgnite function to return if it did not find a block to replace with air. This pull request fixes that by segregating the Fireball Penetration code to a doFireballPenetration function.