### PR TITLE
Director Changes

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/directors/CannonDirectorManager.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/directors/CannonDirectorManager.java
@@ -3,6 +3,7 @@ package net.countercraft.movecraft.combat.movecraftcombat.directors;
 import java.util.*;
 
 import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
+import net.countercraft.movecraft.combat.movecraftcombat.utils.DirectorUtils;
 import net.countercraft.movecraft.combat.movecraftcombat.utils.LegacyUtils;
 import net.countercraft.movecraft.craft.CraftManager;
 import org.bukkit.*;
@@ -160,10 +161,9 @@ public class CannonDirectorManager extends DirectorManager {
                 tntVector.setY(0);
                 double horizontalSpeed = tntVector.length();
                 tntVector = tntVector.normalize(); // you normalize it for comparison with the new direction to see if we are trying to steer too far
-                Block targetBlock = p.getTargetBlock(Config.Transparent, Config.CannonDirectorRange);
+                Block targetBlock = DirectorUtils.getDirectorBlock(p);
                 Vector targetVector;
-                // This is horrible but I'm not sure how else to do it, targetBlock == null doesn't work because getTargetBlock never returns null.
-                if (targetBlock.getType().equals(Material.AIR)) { // the player is looking at nothing, shoot in that general direction
+                if (targetBlock == null) { // the player is looking at nothing, shoot in that general direction
                     targetVector = p.getLocation().getDirection();
                 } else { // shoot directly at the block the player is looking at (IE: with convergence)
                     targetVector = targetBlock.getLocation().toVector().subtract(tnt.getLocation().toVector());

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/utils/DirectorUtils.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/utils/DirectorUtils.java
@@ -1,0 +1,63 @@
+package net.countercraft.movecraft.combat.movecraftcombat.utils;
+
+import net.countercraft.movecraft.combat.movecraftcombat.config.Config;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.util.BlockIterator;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Iterator;
+
+public class DirectorUtils {
+    @Nullable
+    public static Block getDirectorBlock(@NotNull Player player) {
+        Iterator<Block> itr = new BlockIterator(player, Math.min(Config.CannonDirectorRange, distanceToRender(player.getLocation())));
+        while (itr.hasNext()) {
+            Block block = itr.next();
+            Material material = block.getType();
+            if (Config.Transparent == null) {
+                if (!material.equals(Material.AIR)) {
+                    return block;
+                }
+            } else {
+                if (!Config.Transparent.contains(material)) {
+                    return block;
+                }
+            }
+        }
+        return null;
+    }
+
+
+    private static int distanceToRender(Location location) {
+        int chunkDisplacementX,chunkDisplacementZ;
+        int renderDistance = Bukkit.getServer().getViewDistance() << 4;
+        int chunkX = location.getChunk().getX() << 4; //minimum x and z positions in the chunk
+        int chunkZ = location.getChunk().getZ() << 4;
+        if (location.getDirection().getX() > 0) { //get the number that must be added to the coordinate to move it
+            chunkDisplacementX = 15 - location.getBlockX()+chunkX; //to the edge of the chunk
+        } else {
+            chunkDisplacementX = chunkX - location.getBlockX();
+        }
+        if (location.getDirection().getZ() > 0) {
+            chunkDisplacementZ = 15 - location.getBlockZ()+chunkZ;
+        } else {
+            chunkDisplacementZ = chunkZ - location.getBlockZ();
+        }
+        //add a quarter rotation to make the maths easier
+        //now theta = 0 is in the positive X direction
+        double theta =Math.toRadians((location.getYaw() + 90F) % 360F);
+
+        //We then take the sine of the angle times the X magnitude or the sine of the angle times the z magnitude,
+        //whichever is smaller to establish the distance the ray travels before bumping into either edge of render.
+        double horizontalDistance = Math.min(Math.abs((renderDistance + Math.abs(chunkDisplacementX))/Math.cos(theta)),
+                Math.abs((renderDistance+Math.abs(chunkDisplacementZ))/Math.sin(theta)));
+        double finalDistance = Math.min(Math.abs(horizontalDistance / Math.cos(Math.toRadians(location.getPitch()))),
+                Math.abs(location.getBlockY()/Math.sin(Math.toRadians(location.getPitch())))); //and now vertical distance
+        return (int) finalDistance; //casting to an int will floor the result, giving us a bit of safety.
+    }
+}


### PR DESCRIPTION
Cannon Directors currently use ``LivingEntity.getTargetBlock()`` to find their targeted location, which only functions correctly if CannonDirectorRange is less than 120. This is because spigot arbitrarily limits their getTargetBlock method to not search beyond 120 blocks for fear of searching unloaded chunks and causing issues. While no issues were found with checking blocks outside of render in my testing, it still has the potential to load chunks, which is not something we necessarily want to do.

This pull request creates a custom raycast function that directly uses a BlockIterator towards either the CannonDirectorDistance or the distance to server render, whichever is closer.