### PR TITLE
Improved Contact Explosives

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/MovecraftCombat.java
@@ -69,6 +69,7 @@ public final class MovecraftCombat extends JavaPlugin {
         Config.EnableContactExplosives = getConfig().getBoolean("EnableContactExplosives", true);
         Config.CannonDirectorDistance = getConfig().getInt("CannonDirectorsDistance", 100);
         Config.CannonDirectorRange = getConfig().getInt("CannonDirectorRange", 120);
+        Config.ContactExplosivesMaxImpulseFactor = getConfig().getDouble("ContactExplosivesMaxImpulseFactor", 10.0);
         reloadTypes();
 
         Object tool = getConfig().get("DirectorTool");

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/config/Config.java
@@ -20,6 +20,7 @@ public class Config {
 
     // Contact Explosives
     public static boolean EnableContactExplosives = true;
+    public static double ContactExplosivesMaxImpulseFactor = 10;
 
     // Cannon Directors
     public static int CannonDirectorDistance = 100;

--- a/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/directors/CannonDirectorManager.java
+++ b/src/main/java/net/countercraft/movecraft/combat/movecraftcombat/directors/CannonDirectorManager.java
@@ -42,10 +42,10 @@ public class CannonDirectorManager extends DirectorManager {
         }
 
         processTracers();
+        processTNTContactExplosives(); //Changed the order so newly directed TNT is not affected by Contact Explosives
         processDirectors();
         // then, removed any exploded or invalid TNT from tracking
         tracking.keySet().removeIf(tnt -> !tnt.isValid() || tnt.getFuseTicks() <= 0);
-        processTNTContactExplosives();
 
         lastCheck = System.currentTimeMillis();
     }
@@ -166,7 +166,6 @@ public class CannonDirectorManager extends DirectorManager {
                 tntVector = tntVector.normalize(); // you normalize it for comparison with the new direction to see if we are trying to steer too far
                 Block targetBlock = DirectorUtils.getDirectorBlock(p);
                 Vector targetVector;
-                // This is horrible but I'm not sure how else to do it, targetBlock == null doesn't work because getTargetBlock never returns null.
                 if (targetBlock == null || targetBlock.getType().equals(Material.AIR)) { // the player is looking at nothing, shoot in that general direction
                     targetVector = p.getLocation().getDirection();
                 }
@@ -211,7 +210,8 @@ public class CannonDirectorManager extends DirectorManager {
         // explode
         for (TNTPrimed tnt : tracking.keySet()) {
             double vel = tnt.getVelocity().lengthSquared();
-            if (vel < tracking.getDouble(tnt) / 10.0) {
+            if (vel < tracking.getDouble(tnt) / Config.ContactExplosivesMaxImpulseFactor) {
+                tnt.setVelocity(new Vector(0,0,0)); //freeze it in place to prevent sliding
                 tnt.setFuseTicks(0);
             }
             else {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,6 +43,7 @@ TransparentBlocks: # List of MATERIAL_NAMES which are ignored for directing.  Se
 
 # Contact Explosives
 EnableContactExplosives: true # Enable TNT contact explosives
+ContactExplosivesMaxImpulseFactor: 10.0
 
 # Durability Override
 DurabilityOverride: # List of block IDs: ignore percent

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -43,7 +43,9 @@ TransparentBlocks: # List of MATERIAL_NAMES which are ignored for directing.  Se
 
 # Contact Explosives
 EnableContactExplosives: true # Enable TNT contact explosives
-ContactExplosivesMaxImpulseFactor: 10.0
+ContactExplosivesMaxImpulseFactor: 10.0 # The maximum fraction of its velocity tnt can be reduced to in a single tick and not detonate.
+                                        # For example, with the default value of 10.0, TNT can be reduced to 1/10th of its velocity without detonating.
+                                        # Lower values are more sensitive.
 
 # Durability Override
 DurabilityOverride: # List of block IDs: ignore percent


### PR DESCRIPTION
The contact explosives system was designed to prevent ships with completely flat sides from becoming dominant, but with the advent of cannon directors we have seen a similar thing crop back up. This PR makes some slight improvements to the contact explosive code as well as making the sensitivity configurable.