### PR TITLE
Fixing legacy config

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -46,8 +46,8 @@ EnableContactExplosives: true # Enable TNT contact explosives
 
 # Durability Override
 DurabilityOverride: # List of block IDs: ignore percent
-  END_STONE: 80
-  END_STONE_BRICKS: 80
+  ENDER_STONE: 80
+  END_BRICKS: 80
 
 # Fireball Lifespan
 FireballLifespan: 6 # Lifespan of fireballs in seconds


### PR DESCRIPTION
Endstone and endbrick material enums are different in versions equal or below 1.12.2.