### PR TITLE
Fix AA Directors

### DIFF
--- a/src/main/java/net/countercraft/movecraft/combat/features/directors/AADirectors.java
+++ b/src/main/java/net/countercraft/movecraft/combat/features/directors/AADirectors.java
@@ -68,7 +68,7 @@ public class AADirectors extends Directors implements Listener {
     }
 
     private void processFireball(@NotNull SmallFireball fireball) {
-        if (fireball.getShooter() instanceof org.bukkit.entity.LivingEntity)
+        if (fireball.getShooter() instanceof LivingEntity && !(fireball.getShooter() instanceof Player))
             return;
 
         Craft c = CraftManager.getInstance().fastNearestCraftToLoc(fireball.getLocation());


### PR DESCRIPTION
`Player` is a subinterface of `LivingEntity`, so we need to ensure that we don't ignore fireballs whose shooter has been set to a player - we do this later at Line 87

[Without fix](https://streamable.com/7avnhx)
[With fix](https://streamable.com/t7w9l0)